### PR TITLE
Fixing Cache Issue with Artwork Legacy

### DIFF
--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include "artwork_internal.h"
+#include "cache_paths.h"
 #include "../../deadbeef.h"
 #include "../../common.h"
 
@@ -57,31 +58,6 @@ void cache_lock (void)
 void cache_unlock (void)
 {
     deadbeef->mutex_unlock (files_mutex);
-}
-
-int make_cache_root_path (char *path, const size_t size)
-{
-    const char *xdg_cache = getenv (CACHEDIR);
-    #ifdef __MINGW32__
-    // replace backslashes with normal slashes
-    char xdg_cache_conv[strlen(xdg_cache)+1];
-    if (strchr(xdg_cache, '\\')) {
-        trace ("plt_insert_file_int: backslash(es) detected: %s\n", xdg_cache);
-        strcpy (xdg_cache_conv, xdg_cache);
-        char *slash_p = xdg_cache_conv;
-        while (slash_p = strchr(slash_p, '\\')) {
-            *slash_p = '/';
-            slash_p++;
-        }
-        xdg_cache = xdg_cache_conv;
-    }
-    #endif
-    const char *cache_root = xdg_cache ? xdg_cache : getenv (HOMEDIR);
-    if (snprintf (path, size, xdg_cache ? "%s/deadbeef/" : "%s/.cache/deadbeef/", cache_root) >= size) {
-        trace ("Cache root path truncated at %d bytes\n", (int)size);
-        return -1;
-    }
-    return 0;
 }
 
 static int

--- a/plugins/artwork-legacy/cache_paths.c
+++ b/plugins/artwork-legacy/cache_paths.c
@@ -38,17 +38,17 @@ extern DB_functions_t *deadbeef;
 
 // Maybe put this in utils?
 #ifdef __MINGW32__
-#define canonicalize_nix(str) replace_char(str, '\\', '/')
-#define canonicalize_sys(str) replace_char(str, '/', '\\')
+#define canonicalize_nix(str) replace_char (str, '\\', '/')
+#define canonicalize_sys(str) replace_char (str, '/', '\\')
 #else
 #define canonicalize_nix(str)
 #define canonicalize_sys(str)
 #endif
 
 static void
-replace_char(char* str, char c, char r) {
+replace_char (char* str, char c, char r) {
     while (*str != '\0') {
-        if(*str == c) {
+        if (*str == c) {
             *str = r;
         }
         ++str;
@@ -79,21 +79,21 @@ make_cache_root_path (char *path, const size_t size) {
     const char *sub_dir  = base_dir ? sys_dir : usr_dir;
     size_t      sub_len  = (base_dir ? sizeof(sys_dir): sizeof(usr_dir)) - 1;
 
-    memset(path, '\0', size);
+    memset (path, '\0', size);
     base_dir = base_dir ? base_dir : getenv (HOMEDIR);
     if (!base_dir) {
         trace ("Artwork File Cache: Can't find a suitable cache root directory in the environment variables!\n");
         return -1;
     }
 
-    size_t base_len = strlen(base_dir);
+    size_t base_len = strlen (base_dir);
     if ((base_len + sub_len) >= size) {
         trace ("Artwork File Cache: Cache root directory longer than %d bytes\n", (int)size - 1);
         return -1;
     }
-    memcpy(path, base_dir, base_len);
-    memcpy(path + base_len, sub_dir, sub_len);
-    canonicalize_nix(path);
+    memcpy (path, base_dir, base_len);
+    memcpy (path + base_len, sub_dir, sub_len);
+    canonicalize_nix (path);
     return 0;
 }
 

--- a/plugins/artwork-legacy/cache_paths.c
+++ b/plugins/artwork-legacy/cache_paths.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
+#include <stdint.h>
 
 #include "cache_paths.h"
 #include "../../common.h" // For CACHEDIR & HOMEDIR
@@ -53,6 +55,59 @@ replace_char (char* str, char c, char r) {
         }
         ++str;
     }
+}
+
+static int
+is_illegal_windows_char(char c) {
+    // Forbidden characters in a windows file name: <>:"/\|?* and codepoints with value < 32
+    // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    const char bad_chars[] = { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
+    for (int i = 0; i < sizeof(bad_chars); i++) {
+        if(c == bad_chars[i]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+is_illegal_windows_name (const char* str) {
+    // A file can't be named these regardless of case.
+    // "CON", "PRN", "AUX", "NUL",
+    // "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+    // "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+
+    // Also if a dot follows right after any of these it's forbidden as well
+    // since windows treats that as a file extension.
+    static const uint32_t com = ('C' << 16) | ('O' << 8) | 'M';
+    static const uint32_t lpt = ('L' << 16) | ('P' << 8) | 'T';
+    static const uint32_t names[] = {
+        ('A' << 16) | ('U' << 8) | 'X',
+        ('C' << 16) | ('O' << 8) | 'N',
+        ('N' << 16) | ('U' << 8) | 'L',
+        ('P' << 16) | ('R' << 8) | 'N'
+    };
+    uint32_t val = 0;
+    for (int i = 0; i < 3; i++) {
+        char tmp = str[i];
+        if(str[i] == '\0') {
+            return 0;
+        }
+        val <<= 8;
+        val  |= tmp;
+    }
+    val &= 0xdfdfdf; // Make case insensitive.
+    if (str[3] >= '0' && str[3] <= '9' && (val == com || val == lpt) && (str[4] == '\0' || str[4] == '.')) {
+        return 1;
+    }
+    if (str[3] == '\0' || str[3] == '.') {
+        for (int i = 0; i < 4; i++) {
+            if(val == names[i]) {
+                return 1;
+            }
+        }
+    }
+    return 0;
 }
 
 // esc_char is needed to prevent using file path separators,

--- a/plugins/artwork-legacy/cache_paths.c
+++ b/plugins/artwork-legacy/cache_paths.c
@@ -127,7 +127,7 @@ sanitize_name_for_file_system (const char* name, char* clean, size_t clean_capac
     const char* name_end = name;
     // An other possibility is escape to hex, but the old esc_char function just used `_`
     while (*name_end != '\0' && (length + 1) < clean_capacity) {
-        char c = *name_end;
+        unsigned char c = *name_end;
         if (isspace (c)) {
             c = ' ';
         }

--- a/plugins/artwork-legacy/cache_paths.c
+++ b/plugins/artwork-legacy/cache_paths.c
@@ -1,0 +1,169 @@
+/*
+    Album Art plugin for DeaDBeeF
+    Copyright (C) 2009-2011 Viktor Semykin <thesame.ml@gmail.com>
+    Copyright (C) 2009-2013 Alexey Yakovenko <waker@users.sourceforge.net>
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "cache_paths.h"
+#include "../../common.h" // For CACHEDIR & HOMEDIR
+
+// Get rid of redefinition warnings.
+#ifdef trace
+#undef trace
+#endif
+extern DB_functions_t *deadbeef;
+#define trace(...) { deadbeef->log (__VA_ARGS__); }
+
+// esc_char is needed to prevent using file path separators,
+// e.g. to avoid writing arbitrary files using "../../../filename"
+static char
+esc_char (char c) {
+#ifndef WIN32
+    if (c == '/') {
+        return '\\';
+    }
+#else
+    if (c == '/' || c == ':') {
+        return '_';
+    }
+#endif
+    return c;
+}
+
+int
+make_cache_root_path (char *path, const size_t size) {
+    const char *xdg_cache = getenv (CACHEDIR);
+    #ifdef __MINGW32__
+    // replace backslashes with normal slashes
+    char xdg_cache_conv[strlen(xdg_cache)+1];
+    if (strchr(xdg_cache, '\\')) {
+        trace ("plt_insert_file_int: backslash(es) detected: %s\n", xdg_cache);
+        strcpy (xdg_cache_conv, xdg_cache);
+        char *slash_p = xdg_cache_conv;
+        while (slash_p = strchr(slash_p, '\\')) {
+            *slash_p = '/';
+            slash_p++;
+        }
+        xdg_cache = xdg_cache_conv;
+    }
+    #endif
+    const char *cache_root = xdg_cache ? xdg_cache : getenv (HOMEDIR);
+    if (snprintf (path, size, xdg_cache ? "%s/deadbeef/" : "%s/.cache/deadbeef/", cache_root) >= size) {
+        trace ("Cache root path truncated at %d bytes\n", (int)size);
+        return -1;
+    }
+    return 0;
+}
+
+int
+make_cache_dir_path (char *path, int size, const char *artist, int img_size) {
+    char esc_artist[NAME_MAX+1];
+    if (artist) {
+        size_t i = 0;
+        while (artist[i] && i < NAME_MAX) {
+            esc_artist[i] = esc_char (artist[i]);
+            i++;
+        }
+        esc_artist[i] = '\0';
+    }
+    else {
+        strcpy (esc_artist, "Unknown artist");
+    }
+
+    if (make_cache_root_path (path, size) < 0) {
+        return -1;
+    }
+
+    const size_t size_left = size - strlen (path);
+    int path_length;
+    if (img_size == -1) {
+        path_length = snprintf (path+strlen (path), size_left, "covers/%s/", esc_artist);
+    }
+    else {
+        path_length = snprintf (path+strlen (path), size_left, "covers-%d/%s/", img_size, esc_artist);
+    }
+    if (path_length >= size_left) {
+        trace ("Cache path truncated at %d bytes\n", size);
+        return -1;
+    }
+
+    return 0;
+}
+
+int
+make_cache_path2 (char *path, int size, const char *fname, const char *album, const char *artist, int img_size) {
+    path[0] = '\0';
+
+    if (!album || !*album) {
+        if (fname) {
+            album = fname;
+        }
+        else if (artist && *artist) {
+            album = artist;
+        }
+        else {
+            trace ("not possible to get any unique album name\n");
+            return -1;
+        }
+    }
+    if (!artist || !*artist) {
+        artist = "Unknown artist";
+    }
+
+    #ifdef __MINGW32__
+    if (make_cache_dir_path (path, size, artist, img_size)) {
+        return -1;
+    }
+    #else
+    if (make_cache_dir_path (path, size-NAME_MAX, artist, img_size)) {
+        return -1;
+    }
+    #endif
+
+    int max_album_chars = min (NAME_MAX, size - strlen (path)) - sizeof ("1.jpg.part");
+    #ifdef __MINGW32__
+    // override char limit todo
+    max_album_chars = 250;
+    #endif
+    if (max_album_chars <= 0) {
+        trace ("Path buffer not long enough for %s and filename\n", path);
+        return -1;
+    }
+
+    char esc_album[max_album_chars+1];
+    const char *palbum = strlen (album) > max_album_chars ? album+strlen (album)-max_album_chars : album;
+    size_t i = 0;
+    do {
+        esc_album[i] = esc_char (palbum[i]);
+    } while (palbum[i++]);
+
+    sprintf (path+strlen (path), "%s%s", esc_album, ".jpg");
+    return 0;
+}
+
+void
+make_cache_path (char *path, int size, const char *album, const char *artist, int img_size) {
+    make_cache_path2 (path, size, NULL, album, artist, img_size);
+}

--- a/plugins/artwork-legacy/cache_paths.c
+++ b/plugins/artwork-legacy/cache_paths.c
@@ -110,6 +110,82 @@ is_illegal_windows_name (const char* str) {
     return 0;
 }
 
+// Maybe put this in utils as well?
+static size_t
+sanitize_name_for_file_system (const char* name, char* clean, size_t clean_capacity) {
+    if(clean_capacity < 1) {
+        return 0;
+    }
+    // Trim leading white spaces
+    while (isspace (*name)) {
+        name++;
+    }
+
+    // Most Unix OSes only care about `/`, and `NULL`, but Mac OS does not like `:`
+    // https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+    size_t length = 0;
+    const char* name_end = name;
+    // An other possibility is escape to hex, but the old esc_char function just used `_`
+    while (*name_end != '\0' && (length + 1) < clean_capacity) {
+        char c = *name_end;
+        if (isspace (c)) {
+            c = ' ';
+        }
+        if (c == '/') {
+            c = '\\';
+        }
+        if (c == ':') {
+            c = '_';
+        }
+        // While only a restriction on windows these seem like a bad idea in general
+        if (c < 32) {
+            c = '_';
+        }
+        #ifdef __MINGW32__
+        if (is_illegal_windows_char (c)) {
+            c = '_';
+        }
+        #endif
+
+        clean[length] = c;
+        length++;
+        name_end++;
+    }
+    clean[length] = '\0';
+    //  Just an empty string nothing more process.
+    if(length < 1) {
+        return 0;
+    }
+
+    // A leading dash can make interacting with a file from the commandline a pain
+    if(clean[0] == '-') {
+        clean[0] = '_';
+    }
+
+    // Adjust length to trim trailing spaces
+    while (length > 0 && isspace (*(clean + length - 1))) {
+        length--;
+    }
+
+    #ifdef __MINGW32__
+    // prepend an underscore to the name
+    if (is_illegal_windows_name (clean)) {
+        if(length + 1 >= clean_capacity) {
+            length--; // truncate by one then
+        }
+        memmove (clean + 1, clean, length);
+        length++;
+        clean[0] = '_';
+        clean[length] = '\0';
+    }
+    // File names can't end with a period `.` on windows
+    if(clean[length - 1] == '.') {
+        clean[length - 1] = '_';
+    }
+    #endif
+    return length;
+}
+
 // esc_char is needed to prevent using file path separators,
 // e.g. to avoid writing arbitrary files using "../../../filename"
 static char
@@ -154,17 +230,9 @@ make_cache_root_path (char *path, const size_t size) {
 
 int
 make_cache_dir_path (char *path, int size, const char *artist, int img_size) {
-    char esc_artist[NAME_MAX+1];
+    char esc_artist[NAME_MAX] = "Unknown artist";
     if (artist) {
-        size_t i = 0;
-        while (artist[i] && i < NAME_MAX) {
-            esc_artist[i] = esc_char (artist[i]);
-            i++;
-        }
-        esc_artist[i] = '\0';
-    }
-    else {
-        strcpy (esc_artist, "Unknown artist");
+        sanitize_name_for_file_system(artist, esc_artist, NAME_MAX);
     }
 
     if (make_cache_root_path (path, size) < 0) {

--- a/plugins/artwork-legacy/cache_paths.h
+++ b/plugins/artwork-legacy/cache_paths.h
@@ -21,14 +21,19 @@
 
     3. This notice may not be removed or altered from any source distribution.
 */
-#ifndef __ARTWORK_CACHE_H
-#define __ARTWORK_CACHE_H
+#ifndef __ARTWORK_CACHE_PATHS_H
+#define __ARTWORK_CACHE_PATHS_H
 
-void cache_lock(void);
-void cache_unlock(void);
-void remove_cache_item(const char *entry_path, const char *subdir_path, const char *subdir_name, const char *entry_name);
-void cache_configchanged(void);
-void start_cache_cleaner(void);
-void stop_cache_cleaner(void);
+int
+make_cache_root_path (char *path, const size_t size);
 
-#endif /*__ARTWORK_CACHE_H*/
+int
+make_cache_dir_path (char *path, int size, const char *artist, int img_size);
+
+int
+make_cache_path2 (char *path, int size, const char *fname, const char *album, const char *artist, int img_size);
+
+void
+make_cache_path (char *path, int size, const char *album, const char *artist, int img_size);
+
+#endif /*__ARTWORK_CACHE_PATHS_H*/

--- a/plugins/artwork-legacy/hash.c
+++ b/plugins/artwork-legacy/hash.c
@@ -1,0 +1,94 @@
+/*
+    Tabulated Hashing
+    Copyright (C) 2020 Keith Cancel <admin@keith.pro>
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+/*
+* ======= Description of Algorthim =======
+* The hash algorithim I have implemented is called tabulated hashing. It's a
+* very straight forward idea for hashing strings. Simply generate a table of
+* random numbers for each possible value a character or unit in a string. Then
+* take your current hash value and rotate it by 1 bit. Then take the current
+* unit in the string and look it up in your table and xor with the rotated
+* current value. Repeat these for each character/unit in your string.
+*
+* It also has a couple nice properties. First it really easy to generate a new
+* function just generate a new randome table. Useful for any algorthims that
+* require to generate new hash functions on the fly. Secondly, it's pair-wise
+* independent except till the strings get longer. The number of pair-wise
+* independent bits in the hash output for a 64 bit hash is: 64 - L - 1
+* Where L is the length of the string.
+*/
+
+#include "hash.h"
+
+// openssl rand -hex 128
+static const uint64_t v_tbl[] = {
+    0x50b39fd87724c98c, 0x8ddbf0214aa3cbd5, 0x4064b5fe42f09d60, 0x8f03d6c854174876,
+    0x1bf66d8086e397ad, 0x2612f2fc45376459, 0x0fe4a54bc60101fd, 0x779f417e3bf149c7,
+    0x40556ac5dce90ba9, 0xdf15b4e8cc47fa46, 0x297191c88722e4ee, 0x1f9bcf9b21cf8079,
+    0xb47980b136b3dea1, 0xe13403a9095790f9, 0x9af58de272a90ef9, 0xf0f0e29f65df5162
+};
+// bitwise rotate left, compilers optimize this to a rotate instruction.
+#define ROL64_R(x, y) ((x >> y) | ( x << (64 - y)))
+
+// Frac(sqrt(2)) mainly for zero length strings could be any random value.
+#define HASH_INIT 0x6a09e667f3bcc908
+
+// Instead of a table 256 entries which would take 256 * 8 Bytes or 2 KB it is
+// more efficeint to split a byte in half reducing the table to only 128 bytes
+// small enough to fit in just a couple cache lines. Also small enough to not
+// cause issues on most micro-controllers.
+
+static inline uint64_t
+hash_one_byte (uint64_t cur_hash, uint8_t byte) {
+    cur_hash  = ROL64_R (cur_hash, 1);
+    cur_hash ^= v_tbl[byte >> 4];  // hash upper half
+    cur_hash  = ROL64_R (cur_hash, 1);
+    cur_hash ^= v_tbl[byte & 0xf]; // hash lower half
+    return cur_hash;
+}
+
+uint64_t
+hash_bytes (const uint8_t* bytes, size_t len) {
+    uint64_t cur_hash = HASH_INIT;
+    for (size_t i = 0; i < len; i++) {
+        cur_hash = hash_one_byte (cur_hash, bytes[i]);
+    }
+    return cur_hash;
+}
+
+uint64_t
+hash_string_continue (uint64_t hash, const char* str) {
+    uint64_t cur_hash = hash;
+    const char* c = str;
+    while (*c != '\0') {
+        cur_hash = hash_one_byte (cur_hash, (uint8_t)(*c));
+        ++c;
+    }
+    return cur_hash;
+}
+
+uint64_t
+hash_string (const char* str) {
+    return hash_string_continue (HASH_INIT, str);
+}

--- a/plugins/artwork-legacy/hash.h
+++ b/plugins/artwork-legacy/hash.h
@@ -1,0 +1,40 @@
+/*
+    Tabulated Hashing
+    Copyright (C) 2020 Keith Cancel <admin@keith.pro>
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+#ifndef _TAB_HASH_H
+#define _TAB_HASH_H
+
+#include <stdint.h>
+#include <wchar.h>
+
+uint64_t
+hash_bytes (const uint8_t* bytes, size_t len);
+
+// input is a null terminated string
+uint64_t
+hash_string (const char* str);
+
+// Easy calculation for concatenated strings without have to concat in memory.
+uint64_t
+hash_string_continue (uint64_t hash, const char* str);
+
+#endif // _TAB_HASH_H


### PR DESCRIPTION
Hello again, so while trying to figure out to get the album artwork plugin to work well with covers files. Now that scandir is working properly, I have noticed multiple problems with the current way it generates names for the cache. This pull request will fix these issues. It might even be a good idea to push/merge this change to the main plugin since they mostly are platform agnostic.

### Noticed Issues
- **Name Collisions**: The current method creates a path like _{artist}/{album}.jpg_ this is far from unique enough. For instance I have an album that has a digital version and vinyl version (with a bonus track). The covers between the two are not the same, but because how the caching works they will use the same image. An other interesting example is I have an an album that has a original and remix version. However, the only difference between them is the cover, and track names. Again this leads to the incorrect art being displayed.

- **Un-needed Cache Files**: I have a fair amount collaborative albums and sound tracks. So for a given album tracks will each have a different artist. The current structure will produce a cache file multiple times for given album. This just wastes space.

- **Missing Sanitization**: If you look at the image below you will see a directory inside. This is because the albums name is Sprint/ARIA. On line: 895 of artwork.c it only sanitizes backwards slashes. It also tries to change what slash depending OS. Both Linux and windows forward slash can't be part of file or directory name. Even worse windows has a much larger list forbidden names and characters. This just leads to a complete failure of art loading those instances. I also noticed problem if some reason artist name had trailing space at the end which is an other forbidden instance on windows. Moreover, windows also has a list forbidden names for directories and files. This causes issues with an artist I have named CON. 
![cover art](https://user-images.githubusercontent.com/8355441/79033516-59364700-7b9e-11ea-9311-f98f85bc673e.png)


- **Mojibake**: Current plugin produces a lot mojibake in the cache directory. Yet it also seems to not generate it in other cases. However, while this works fine some times other times art does not load at all. I suspect this because the garbled mess contains a forbidden characters.  

### What I did.

- Now Let's address the first point of collisions. My first thought was to use path for the music file since that case each file would be unique. While that works fine for someone who uses gap-less audio with cue sheets. If the tracks are split it would generate and entry in the file cache for each track. So instead of using the music file path, I use the directory path the music file is in. In such cases users already have such versions in separate directories anyways. If not the user can easily fix the issue by just organizing their music better. So now I need some way to combine album name and the directories. Just concatenating would lead to long file names. So instead the directory structure will be _{artist}/{hash(album + dir_path)}.jpg_. I am using 64 bit hash function so the chances of collision from hashing for a single artist is basically nil. Hashing also helps us with the other 2 issues we now only need to sanitize the artist name.

- For the last two points it would easier to just _hash(Artist + Album + dir_path)}.jpg_, and being a cache most people would never need to look at the files. However, for debugging or manually deleting things a little structure does not hurt. So I am just gonna sanitize any illegal characters or names for the artist directory. If cleaning the artist name causes a collision with an other artist the hashed path and album name basically make collision highly highly unlikely.

### Newly discovered / Unresolved

- I have yet to address the second issue of extra cache files being generated because of collaborative albulms. Problem is the plugin and how gtkui calls the plugin only provides file path, artist and album. To get extra info require changes to both the plugin and gtkui to fix. However, the gist of what I would do to fix it: The current behavior is use artist or if empty use "Unknown artist". What I would do instead is take advantage the Album Artist tag. If a song has an **Album Artist** use that. If not use the **Artist** tag. If there is no Artist tag use "Unknown artist".

- So the once source of the mojibake folders I have found out is that in art_internal.c is calling mkdir and also rmdir to cleanup the cache folder. However, these expect only ascii range cope points on windows, instead we would need to use the _wrmdir ect... so that would require a new addition to winlib or if the main app has a more platform agnostic call use that. What I do find interesting is the directories still get created with proper Unicode names. So at least on windows this mkdir call may not be necessary. 
![obvious](https://user-images.githubusercontent.com/8355441/79034012-6d7c4300-7ba2-11ea-9931-88ddff2000ac.png)

- However, there seems to some other source of mojibake mainly in that some folder names will have **�** put in their names. Is there a proper Unicode library to use the main plugin for sanitation? From a quick search I If not it might be better to just hash the artist names and avoid the issue entirely and forgo the structure in the cache directory.
![questions](https://user-images.githubusercontent.com/8355441/79033827-dd89c980-7ba0-11ea-876e-d3018990969b.png)
