### PR TITLE
Artwork Legacy: Sanitize cache directory and file names

### DIFF
--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1020,17 +1020,9 @@ esc_char (char c) {
 
 static int
 make_cache_dir_path (char *path, int size, const char *artist, int img_size) {
-    char esc_artist[NAME_MAX+1];
+    char esc_artist[NAME_MAX] = "Unknown artist";
     if (artist) {
-        size_t i = 0;
-        while (artist[i] && i < NAME_MAX) {
-            esc_artist[i] = esc_char (artist[i]);
-            i++;
-        }
-        esc_artist[i] = '\0';
-    }
-    else {
-        strcpy (esc_artist, "Unknown artist");
+        sanitize_name_for_file_system(artist, esc_artist, NAME_MAX);
     }
 
     if (make_cache_root_path (path, size) < 0) {

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1064,19 +1064,30 @@ make_cache_path2 (char *path, int size, const char *fname, const char *album, co
     if (!artist || !*artist) {
         artist = "Unknown artist";
     }
+    // If buffer larger than max path size limit it to NAME_MAX
+    if(size > NAME_MAX) {
+        size = NAME_MAX;
+    }
 
-    if (make_cache_dir_path (path, size-NAME_MAX, artist, img_size)) {
+    if(size < sizeof ("1.jpg.part")) {
+        trace ("Artwork File Cache: Path buffer way too small!\n");
+        return -1;
+    }
+    // Temp file extension or something just make sure there is room for it
+    size -= sizeof ("1.jpg.part");
+
+    if (make_cache_dir_path (path, size, artist, img_size)) {
         return -1;
     }
 
-    int max_album_chars = min (NAME_MAX, size - strlen (path)) - sizeof ("1.jpg.part");
-    if (max_album_chars <= 0) {
+    size -= strlen (path);
+    if (size < 1) {
         trace ("Path buffer not long enough for %s and filename\n", path);
         return -1;
     }
 
-    char esc_album[max_album_chars+1];
-    size_t len = sanitize_name_for_file_system (album, esc_album, max_album_chars + 1);
+    char esc_album[size+1];
+    size_t len = sanitize_name_for_file_system (album, esc_album, size + 1);
     if (len < 1) {
         // Would only happen if the name was entirely spaces or something like that.
         trace ("Artwork File Cache: Not possible to get any unique album name.\n");

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1076,11 +1076,12 @@ make_cache_path2 (char *path, int size, const char *fname, const char *album, co
     }
 
     char esc_album[max_album_chars+1];
-    const char *palbum = strlen (album) > max_album_chars ? album+strlen (album)-max_album_chars : album;
-    size_t i = 0;
-    do {
-        esc_album[i] = esc_char (palbum[i]);
-    } while (palbum[i++]);
+    size_t len = sanitize_name_for_file_system (album, esc_album, max_album_chars + 1);
+    if (len < 1) {
+        // Would only happen if the name was entirely spaces or something like that.
+        trace ("Artwork File Cache: Not possible to get any unique album name.\n");
+        return -1;
+    }
 
     sprintf (path+strlen (path), "%s%s", esc_album, ".jpg");
     return 0;

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1081,6 +1081,7 @@ make_cache_path2 (char *path, int size, const char *fname, const char *album, co
     }
 
     size -= strlen (path);
+    size -= 4; // File extension .jpg
     if (size < 1) {
         trace ("Path buffer not long enough for %s and filename\n", path);
         return -1;


### PR DESCRIPTION
This takes the sanitization changes from the other large pull request. This pull defines a couple functions that detects bad file names and characters on windows. Then I made function that uses those functions to sanitize names.

##### Windows Only
- Replace any of the the forbidden characters with '_'
- If name is a forbidden name prepend '_'
- If name ends with a period replace with '_'

##### On Both *nix & Windows
- Replace '/' with '\\\\' just like the old esc_char function.
- Replace a leading dash with '_'. Using command line tools like rm with such files names is a pain
- Replace ':' with '_'. Mac OS does not like colons in names.
- Trim leading and trailing spaces.
- Replace white space like '\n', '\t' with space.
- Replace control characters with '_'

The control characters and white space is windows requirement but can be annoying to work with such files from the command line on any system. Like typing the new line character without executing your input can be a bother ect... So seems fair to apply to everything.

Windows also requires that files not have leading and trailing spaces. However spaces just require you have to escape everything if using command line tools on other systems. So again it seems fair to also apply this to more than just windows.

##### Buffer Size Calculation
I noticed in album_art_wip branch you just hard-coded the size to 250, and put a todo, and in the master branch well size was being calculated as zero. So I fixed this. 